### PR TITLE
Document decode_into() usage and update benchmark results (ESP32S3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,143 +1,244 @@
 # MicroPython JPEG
 
-A very fast and memory-efficient micropython jpeg decoder and encoder. At the moment only the esp port is supported.
+A fast and memory-efficient JPEG decoder/encoder module for MicroPython (ESP port).
 
-If you are not familiar with building custom firmware, visit the [releases](https://github.com/cnadler86/mp_jpeg/releases) page to download firmware that suits your board!
+## Features
+- JPEG **Decoder**: normal decode (full frame) and **block decode** (tile/strip decode)
+- JPEG **Encoder**
+- `decode_into()` supports **zero-copy writing into a user-provided framebuffer**
+- Designed for embedded UI/animation workloads (cooperative scheduling)
 
-To get the version of the low level driver, you can use the following code:
+---
+
+# Getting started
 
 ```python
 import jpeg
 print("JPEG Driver Version:", jpeg.version())
 ```
 
-## Decoder
+---
 
-### API Reference
+# Decoder
 
-- `Decoder(format="RGB888", rotation=0, block=False)`: Creates a new decoder object.
-  - `pixel_format`: Pixel format for output (`RGB565_BE`, `RGB565_LE`, `CbYCrY`, `RGB888`).
-  - `rotation`: Rotation angle for decoding (0, 90, 180, 270). Default 0.
-  - `block`: Enable block decoding (default: `False`). Each time decode is called, it outputs 8 or 16 line data depending on the image and output format (see `get_block_counts`). If enabled, scale, clipper and rotation are not supported.
-  - `scale_width` and `scale_height`: Resize the output image to the prvided scale. Note: the scale needs to be consistent with the input image and be a multiple of 8.
-  - `clipper_width` and `clipper_height`: This will cut the output image to the specified width and/or height. The clipper_height and clipper_width require integer multiples of 8. The resolution of clipper should be less or equal than scale.
-  - `return_bytes`: if true, the decoder return a bytes-object, otherwise a memoryview, default is false.
-
-- `get_img_info(jpeg_data)`: Returns a list containing the width and height. If the decoder was constructed with `block` enabled, then it will also return the number of blocks that the decoder will need to decode the full image and the heigh of each block (eihter 8 or 16). 
-  - `jpeg_data`: JPEG data to decode.
-
-- `decode(jpeg_data)`: Decodes the JPEG image and returns the decoded image. With block==True, it decodes the next block of the JPEG image and returns the decoded block. The decoder will give you a block of full width and the height will be either 8 or 16 pixels. You can get the block height by `get_img_info`
-  - `jpeg_data`: JPEG data to decode.
-
-### Example
+## Create a decoder
 
 ```python
-import jpeg
-
-# Create a JPEG decoder object
-decoder = jpeg.Decoder(rotation=180, pixel_format="RGB888")
-
-# Prepare the JPEG data for decoding
-jpeg_data = open("path/to/jpeg/image.jpg", "rb").read()
-
-# Decode the JPEG image
-decoded_image = decoder.decode(jpeg_data)
+decoder = jpeg.Decoder(
+    pixel_format="RGB565_LE",
+    rotation=0,
+    block=False,
+    scale_width=0, scale_height=0,
+    clipper_width=0, clipper_height=0,
+    return_bytes=False,
+)
 ```
 
-## Encoder
+### Parameters
+- `pixel_format`: Output pixel format.
+  - Supported: `RGB565_BE`, `RGB565_LE`, `CbYCrY`, `RGB888`
+- `rotation`: `0`, `90`, `180`, `270`
+- `block`:
+  - `False` (default): normal decode (full image per decode)
+  - `True`: block decode mode (each decode produces one block; usually 8 or 16 lines per block)
+  - If `block=True`: scaling/clipper/rotation are not supported (library limitation)
+- `scale_width`, `scale_height`:
+  - Optional output scaling (must match JPEG constraints and be multiple of 8)
+- `clipper_width`, `clipper_height`:
+  - Optional crop (must be multiple of 8; must be <= scale)
+- `return_bytes`:
+  - `False` (default): `decode()` returns `memoryview`
+  - `True`: `decode()` returns `bytes`
 
-### API Reference
+---
 
-- `Encoder(height=240, width=320, format="RGB888", quality=90, rotation=0)`: Creates a new encoder object.
-  - `height`: Height of the input image. Required.
-  - `width`: Width of the input image. Required.
-  - `pixel_format`: Pixel format for input image (RGB888, RGB565, RGBA, YCbYCr, YCbY2YCrY2, CbYCrY, GRAY). Required.
-  - `quality`: JPEG quality (1-100). Default 90.
-  - `rotation`: Rotation angle for encoding (0, 90, 180, 270). Default 0.
-
-- `encode(img_data)`: Encodes the image data to JPEG format and returns the encoded JPEG data.
-  - `img_data`: Raw image data to encode.
-  - Returns the bytes of the encoded image.
-
-### Example
+## get_img_info(jpeg_data)
 
 ```python
-import jpeg
-
-# Create a JPEG encoder object
-encoder = jpeg.Encoder(pixel_format="RGB888", quality=80, rotation=90, width=320, height=240)
-
-# Encode the image data to JPEG format
-image_data = open("path/to/raw/image.bin", "rb").read()
-encoded_jpeg = encoder.encode(image_data)
+info = decoder.get_img_info(jpeg_data)
 ```
 
-## Benchmark Results for ESP32S3
+Returns:
+- normal mode: `[width, height]`
+- block mode: `[width, height, blocks, block_height]`
 
-The following tables present the results of the JPEG decoding and encoding benchmarks performed on an ESP32S3. The image was 240x320.
+Where:
+- `blocks` = number of blocks to decode full image
+- `block_height` is usually `8` or `16`
 
-### Decoder Benchmark
+---
 
-**Input Image Size:** 26,366 bytes.
+## decode(jpeg_data)
 
-| Format    | FPS Normal Decode | FPS Block Decode (15) |
-|-----------|-------------------|-----------------------|
-| RGB565_BE | 21.80             | 34.73                 |
-| RGB565_LE | 21.79             | 34.72                 |
-| RGB888    | 17.61             | 32.14                 |
-| CbYCrY    | 21.85             | 38.17                 |
+```python
+img_or_block = decoder.decode(jpeg_data)
+```
 
-**Input Image Size:** 7,941 bytes  
+- If `block=False`: returns the full decoded frame
+- If `block=True`: returns the next decoded block (full width, height = 8 or 16 lines)
+- When block decoding is finished:
+  - returns `None`
 
-| Format    | FPS Normal Decode | FPS Block Decode (15) |
-|-----------|-------------------|-----------------------|
-| RGB565_BE | 29.65             | 62.27                 |
-| RGB565_LE | 29.66             | 62.27                 |
-| RGB888    | 22.45             | 55.74                 |
-| CbYCrY    | 29.75             | 74.57                 |
+This API is useful when you want the raw block bytes/memoryview and handle placement/output yourself.
 
-Block decode will be faster, because other RAM-type might be used.
+---
 
-### Encoder Benchmark
+## decode_into(jpeg_data, out_buffer, *, blocks=0)  ✅ NEW API
 
-| Quality | FPS RGB888 |
-|---------|------------|
-| 100     | 11.90      |
-| 90      | 17.58      |
-| 80      | 19.62      |
-| 70      | 20.55      |
-| 60      | 21.35      |
+```python
+done = decoder.decode_into(jpeg_data, framebuffer)            # blocks defaults to 0 (FULL)
+done = decoder.decode_into(jpeg_data, framebuffer, blocks=1)  # step
+```
 
-The FPS might vary, depending on the image.
+### Goal
+Decode and write directly into a user-provided buffer (framebuffer).  
+This avoids Python slice copies and reduces GC pressure.
 
-### Build the project
+### Return value
+- Returns **bool**
+  - `True`: this call completed one full decode round (framebuffer is ready)
+  - `False`: not finished yet (only possible in `block=True` with `blocks>0`)
 
-### Setting up the build environment
+### blocks parameter (important)
+- `blocks=0` (**default**): **FULL mode**
+  - Continue decoding from the current progress until the frame is complete
+  - Returns `True`
+- `blocks>0`: **STEP mode**
+  - Decode at most `blocks` blocks from current progress
+  - Returns:
+    - `False` if not finished yet
+    - `True` if finished within this call
+- `blocks<0`: raises `ValueError`
 
-To build the project, follow these instructions:
+### Auto-rewind behavior (by design)
+After a full round is completed, if you call `decode_into()` again with the **same** `jpeg_data`,
+the decoder will automatically restart (rewind) and decode again.
 
-- ESP-IDF: I tested it on version 5.2, 5.3 and 5.4, but it might work with other versions.
-- Clone the micropython repo and this repo in a folder, e.g. "MyJPEG". I used MicroPython version 1.24 but might work also with older versions.
-- You will have to add the ESP JPEG library (I used v0.6.1). To do this, add the following to the dependencies in the respective idf_component.yml file (e.g. in micropython/ports/esp32/main_esp32s3/idf_component.yml):
+This simplifies animation loops (you control whether to call again or switch to the next frame at a higher level).
 
+### Buffer requirements
+- If `block=False`:
+  - `out_buffer` must be at least the full decoded frame size
+- If `block=True`:
+  - `out_buffer` must be large enough to hold the **full frame** (because the module writes each block into the correct offset automatically)
+
+---
+
+# Encoder
+
+## Create an encoder
+
+```python
+enc = jpeg.Encoder(
+    height=240,
+    width=320,
+    pixel_format="RGB888",
+    quality=90,
+    rotation=0,
+)
+```
+
+### Parameters
+- `height`, `width`: required
+- `pixel_format` (input format): supported by driver (e.g. `RGB888`, `RGB565`, `RGBA`, `YCbYCr`, `CbYCrY`, `GRAY`, etc.)
+- `quality`: 1..100
+- `rotation`: `0`, `90`, `180`, `270`
+
+## encode(img_data)
+
+```python
+jpeg_bytes = enc.encode(raw_image_bytes)
+```
+
+Returns `bytes`.
+
+---
+
+# Benchmark
+
+## Benchmark script
+Use the provided `benchmark.py` (updated for the new bool-return `decode_into` API).
+
+## Test image
+- Resolution: **160×160**
+- JPEG size: **9019 bytes**
+- NR = 100
+
+## Decoder results
+
+| Format     | FPS normal decode (`decode`, block=False) | FPS block decode (`decode`, block=True) | FPS block decode + write (python slice) | FPS decode_into step (blocks=1) | FPS decode_into full (blocks=0) |
+|-----------|--------------------------------------------|------------------------------------------|------------------------------------------|----------------------------------|----------------------------------|
+| RGB565_BE | 62.31 | 97.47  | 17.95 | 76.98 | 77.64 |
+| RGB565_LE | 62.31 | 97.37  | 20.28 | 76.92 | 77.76 |
+| RGB888    | 50.84 | 91.83  | 14.56 | 66.53 | 67.11 |
+| CbYCrY    | 62.42 | 106.61 | 20.11 | 77.28 | 78.00 |
+
+### Notes
+- `block decode` is fastest when you only need block output (no full-frame assembly).
+- `python slice` assembly is slow due to Python-level copying.
+- `decode_into` provides a practical middle ground: good speed + direct framebuffer output.
+
+## Encoder results
+
+| Quality | FPS (RGB888) |
+|--------:|--------------:|
+| 100     | 40.52 |
+| 90      | 56.02 |
+| 80      | 60.86 |
+| 70      | 63.29 |
+| 60      | 65.02 |
+
+---
+
+# Build (ESP-IDF / MicroPython external C module)
+
+## Requirements
+- ESP-IDF: tested on 5.2 / 5.3 / 5.4
+- MicroPython: tested around v1.24
+- ESP JPEG library: `espressif/esp_new_jpeg`
+
+Add dependency in `idf_component.yml` (example):
 ```yaml
-espressif/esp_new_jpeg: "^1.0.0"
+dependencies:
+  espressif/esp_new_jpeg: "^1.0.0"
 ```
 
-Alternatively, you can [download the library from the espressif component registry](https://components.espressif.com/components/espressif/esp_new_jpeg/versions/0.6.1?language=en) and unzip the data inside the esp-idf/components folder instead of altering the idf_component.yml file. In this case you might need to rename the folder to "esp_new_jpeg".
+## Build
+```sh
+. <path-to-esp-idf>/export.sh
+cd micropython/ports/esp32
 
-### Build the user module
-
-To build the project, you could do it the following way:
-
-```bash
-. <path2esp-idf>/esp-idf/export.sh
-cd MyJPEG/micropython/ports/esp32
 make USER_C_MODULES=../../../../mp_jpeg/micropython.cmake BOARD=<Your-Board> clean
 make USER_C_MODULES=../../../../mp_jpeg/micropython.cmake BOARD=<Your-Board> submodules
 make USER_C_MODULES=../../../../mp_jpeg/micropython.cmake BOARD=<Your-Board> all
 ```
 
-You can also pass the MP_JPEG_DIR variable to point to the esp_new_jpeg component folder. in ths case you have to build usinf the idf directly.
+---
 
-Micropython and mp_jpeg folders are at the same level. Note that you need those extra "/../"s while been inside the esp32 port folder. If you experience problems, visit [MicroPython external C modules](https://docs.micropython.org/en/latest/develop/cmodules.html).
+# Example usage
+
+## Full decode into framebuffer (fast, simple)
+```python
+import jpeg
+
+img = open("image.jpg","rb").read()
+
+dec = jpeg.Decoder(pixel_format="RGB565_LE", rotation=0, block=True)
+info = dec.get_img_info(img)
+w, h = info[0], info[1]
+
+fb = bytearray(w * h * 2)
+
+done = dec.decode_into(img, fb)   # default blocks=0 FULL
+# done == True
+# fb is ready
+```
+
+## Cooperative decode (UI-friendly)
+```python
+# each frame decode 1 block to avoid blocking UI
+done = dec.decode_into(img, fb, blocks=1)
+if done:
+    # completed this image
+    pass
+```

--- a/README.md
+++ b/README.md
@@ -122,6 +122,61 @@ This simplifies animation loops (you control whether to call again or switch to 
 - If `block=True`:
   - `out_buffer` must be large enough to hold the **full frame** (because the module writes each block into the correct offset automatically)
 
+### Practical guide
+#### 1) Choose pixel format and size the framebuffer
+- `RGB565_BE` / `RGB565_LE` / `CbYCrY`: 2 bytes per pixel
+- `RGB888`: 3 bytes per pixel
+
+```python
+import jpeg
+
+img = open("image.jpg", "rb").read()
+dec = jpeg.Decoder(pixel_format="RGB565_LE", rotation=0, block=True)
+info = dec.get_img_info(img)
+w, h = info[0], info[1]
+
+bytes_per_pixel = 2
+fb = bytearray(w * h * bytes_per_pixel)
+```
+
+#### 2) Full decode (simple, highest throughput per call)
+Use this when you can afford decoding the whole frame in one call.
+
+```python
+done = dec.decode_into(img, fb)  # blocks defaults to 0
+if done:
+    pass
+```
+
+#### 3) STEP decode (cooperative scheduling, UI-friendly)
+Use this when you want to spread decoding across multiple iterations to keep the UI responsive.
+
+```python
+done = dec.decode_into(img, fb, blocks=1)
+if done:
+    pass
+```
+
+#### 4) Correct loop pattern for STEP mode
+`decode_into(..., blocks>0)` can return `False` until the image is complete.
+
+```python
+while True:
+    done = dec.decode_into(img, fb, blocks=1)
+    if done:
+        break
+    # do other work here (render UI, poll input, etc.)
+```
+
+### When to use `decode_into` vs `decode`
+- Prefer `decode_into` when your goal is a full framebuffer for display (avoids Python slice assembly and reduces GC pressure).
+- Use `decode(block=True)` when you need raw block bytes and want to handle placement/output yourself.
+
+### Notes and caveats
+- STEP mode is meaningful when using `block=True` and `blocks>0`.
+- `block=True` has limitations: rotation must be 0, and scaling/clipping are not supported.
+- The decoder auto-rewinds after completing a full round when you call `decode_into()` again with the same `jpeg_data`, which is convenient for animation loops.
+
 ---
 
 # Encoder
@@ -160,18 +215,19 @@ Returns `bytes`.
 Use the provided `benchmark.py` (updated for the new bool-return `decode_into` API).
 
 ## Test image
-- Resolution: **160×160**
-- JPEG size: **9019 bytes**
+- Resolution: **240×240**
+- JPEG size: **32627 bytes**
+- Blocks: **30** (block height: **8**)
 - NR = 100
 
 ## Decoder results
 
 | Format     | FPS normal decode (`decode`, block=False) | FPS block decode (`decode`, block=True) | FPS block decode + write (python slice) | FPS decode_into step (blocks=1) | FPS decode_into full (blocks=0) |
 |-----------|--------------------------------------------|------------------------------------------|------------------------------------------|----------------------------------|----------------------------------|
-| RGB565_BE | 62.31 | 97.47  | 17.95 | 76.98 | 77.64 |
-| RGB565_LE | 62.31 | 97.37  | 20.28 | 76.92 | 77.76 |
-| RGB888    | 50.84 | 91.83  | 14.56 | 66.53 | 67.11 |
-| CbYCrY    | 62.42 | 106.61 | 20.11 | 77.28 | 78.00 |
+| RGB565_BE | 18.47 | 24.65 | 4.82 | 21.38 | 21.52 |
+| RGB565_LE | 18.46 | 24.65 | 4.82 | 21.40 | 21.52 |
+| RGB888    | 16.49 | 23.75 | 3.43 | 20.19 | 20.34 |
+| CbYCrY    | 18.92 | 26.03 | 4.85 | 21.99 | 22.13 |
 
 ### Notes
 - `block decode` is fastest when you only need block output (no full-frame assembly).
@@ -182,11 +238,11 @@ Use the provided `benchmark.py` (updated for the new bool-return `decode_into` A
 
 | Quality | FPS (RGB888) |
 |--------:|--------------:|
-| 100     | 40.52 |
-| 90      | 56.02 |
-| 80      | 60.86 |
-| 70      | 63.29 |
-| 60      | 65.02 |
+| 100     | 10.95 |
+| 90      | 16.88 |
+| 80      | 19.18 |
+| 70      | 20.23 |
+| 60      | 22.46 |
 
 ---
 

--- a/examples/benchmark.py
+++ b/examples/benchmark.py
@@ -2,57 +2,122 @@ from time import ticks_ms
 import jpeg
 import gc
 
-Nr = 100
-with open(f'bigbuckbunny-320x240.jpg', mode="rb") as f:
-    Img = f.read()
+NR = 100
+IMG_PATH = "000.jpeg"
 
-def decoder():
+with open(IMG_PATH, "rb") as f:
+    IMG = f.read()
+
+def fps(n, dt_ms):
+    return n * 1000 / dt_ms if dt_ms > 0 else 0.0
+
+def bpp(fmt):
+    # 依你的 README 格式清單做常用 bpp 推斷
+    if fmt in ("RGB565_BE", "RGB565_LE", "CbYCrY", "YCbYCr"):
+        return 2
+    if fmt in ("RGB888",):
+        return 3
+    if fmt in ("RGBA",):
+        return 4
+    # fallback
+    return 2
+
+def decoder_bench():
     gc.collect()
-    print("Decoder Benchmark")
-    print(f"Input Image Size: {len(Img)} bytes")
-    for format in ('RGB565_BE', 'RGB565_LE', 'RGB888', 'CbYCrY'):
-        print(f"\nFormat: {format}")
-        Decoder = jpeg.Decoder(format=format, rotation=0)
-        start = ticks_ms()
-        for _ in range(Nr):
-            ImgDec = Decoder.decode(Img)
-        print(f"FPS normal decode: {Nr * 1000 / (ticks_ms() - start):.2f}")
-        
-        Decoder = jpeg.Decoder(format=format, rotation=0, block=True)
-        start = ticks_ms()
-        Info = Decoder.get_img_info(Img)
-        blocks = Info[2]
-        for _ in range(Nr):
-            for i in range(blocks):
-                ImgBlock = Decoder.decode(Img)
-        print(f"FPS block decode ({blocks}): {Nr * 1000 / (ticks_ms() - start):.2f}")
+    print("Decoder Benchmark (NEW API)")
+    print("Input Image Size:", len(IMG), "bytes")
 
-        bytes_per_pixel = 2 if format in ('RGB565_BE', 'RGB565_LE') else 3
-        start = ticks_ms()
-        Info = Decoder.get_img_info(Img)
-        framebuffer = bytearray(Info[0] * Info[1] * bytes_per_pixel)
-        blocks = Info[2]
-        for _ in range(Nr):
-            for i in range(blocks):
-                ImgBlock = Decoder.decode(Img)
-                framebuffer[i * len(ImgBlock) : (i + 1) * len(ImgBlock)] = ImgBlock
-        print(f"FPS block decode and write ({blocks}): {Nr * 1000 / (ticks_ms() - start):.2f}")
+    for fmt in ("RGB565_BE", "RGB565_LE", "RGB888", "CbYCrY"):
+        print("\nFormat:", fmt)
+        _bpp = bpp(fmt)
 
-def encoder():
+        # ---- 1) normal decode (block=False) ----
+        dec = jpeg.Decoder(pixel_format=fmt, rotation=0, block=False)
+        t0 = ticks_ms()
+        for _ in range(NR):
+            _ = dec.decode(IMG)
+        dt = ticks_ms() - t0
+        print("FPS normal decode (decode, block=False):", "%.2f" % fps(NR, dt))
+
+        # ---- 2) block decode (decode, block=True) ----
+        dec = jpeg.Decoder(pixel_format=fmt, rotation=0, block=True)
+        info = dec.get_img_info(IMG)
+        w, h, blocks = info[0], info[1], info[2]
+
+        t0 = ticks_ms()
+        for _ in range(NR):
+            for _i in range(blocks):
+                _ = dec.decode(IMG)
+        dt = ticks_ms() - t0
+        print("FPS block decode (decode, block=True, blocks=%d):" % blocks, "%.2f" % fps(NR, dt))
+
+        # ---- prepare framebuffer ----
+        fb = bytearray(w * h * _bpp)
+
+        # ---- 3) block decode + Python write (slice copy) ----
+        # 先取一塊推算 block size（只用於 slice 拼接測試）
+        dec_tmp = jpeg.Decoder(pixel_format=fmt, rotation=0, block=True, return_bytes=True)
+        _ = dec_tmp.get_img_info(IMG)
+        blk0 = dec_tmp.decode(IMG)
+        blk_size = len(blk0)
+
+        # 正式測試：每塊 decode() 回 bytes，再 slice 拷貝到 fb
+        dec3 = jpeg.Decoder(pixel_format=fmt, rotation=0, block=True, return_bytes=True)
+        _ = dec3.get_img_info(IMG)
+
+        t0 = ticks_ms()
+        for _ in range(NR):
+            for i in range(blocks):
+                blk = dec3.decode(IMG)
+                off = i * blk_size
+                fb[off:off + blk_size] = blk
+        dt = ticks_ms() - t0
+        print("FPS block decode + write (python slice):", "%.2f" % fps(NR, dt))
+
+        # ---- 4) NEW: decode_into step (blocks=1) ----
+        # 每輪做 blocks 次，每次做 1 block，done 只有最後一次會 True
+        dec4 = jpeg.Decoder(pixel_format=fmt, rotation=0, block=True)
+        _ = dec4.get_img_info(IMG)
+
+        t0 = ticks_ms()
+        for _ in range(NR):
+            for _i in range(blocks):
+                done = dec4.decode_into(IMG, fb, blocks=1)
+        dt = ticks_ms() - t0
+        print("FPS decode_into step (blocks=1):", "%.2f" % fps(NR, dt))
+
+        # ---- 5) NEW: decode_into full (default blocks=0) ----
+        # 每輪只呼叫一次，應該直接完成一輪 (done=True)
+        dec5 = jpeg.Decoder(pixel_format=fmt, rotation=0, block=True)
+        _ = dec5.get_img_info(IMG)
+
+        t0 = ticks_ms()
+        for _ in range(NR):
+            done = dec5.decode_into(IMG, fb)  # default blocks=0 (full)
+            # 理論上 done 應為 True
+        dt = ticks_ms() - t0
+        print("FPS decode_into full (default blocks=0):", "%.2f" % fps(NR, dt))
+
+
+def encoder_bench():
     print("\nEncoder Benchmark")
-    Decoder = jpeg.Decoder(format='RGB888', rotation=0)
-    Info = Decoder.get_img_info(Img)
-    ImgDec = bytes(Decoder.decode(Img))
-    del Decoder
+    # 先解成 RGB888 當作 encoder input
+    dec = jpeg.Decoder(pixel_format="RGB888", rotation=0, block=False)
+    info = dec.get_img_info(IMG)
+    w, h = info[0], info[1]
+    img_dec = bytes(dec.decode(IMG))
+    del dec
     gc.collect()
-    for quality in (100, 90, 80, 70, 60):
-        print(f"\nQuality: {quality}")
-        Encoder = jpeg.Encoder(format='RGB888', quality=quality, height=Info[1], width=Info[0])
-        start = ticks_ms()
-        for _ in range(Nr):
-            ImgEnc = Encoder.encode(ImgDec)
-        print(f"FPS encode quality {quality}: {Nr * 1000 / (ticks_ms() - start):.2f}")
+
+    for q in (100, 90, 80, 70, 60):
+        enc = jpeg.Encoder(pixel_format="RGB888", quality=q, height=h, width=w)
+        t0 = ticks_ms()
+        for _ in range(NR):
+            _ = enc.encode(img_dec)
+        dt = ticks_ms() - t0
+        print("FPS encode quality %d:" % q, "%.2f" % fps(NR, dt))
         gc.collect()
 
-decoder()
-encoder()
+
+decoder_bench()
+encoder_bench()

--- a/examples/benchmark.py
+++ b/examples/benchmark.py
@@ -1,123 +1,286 @@
-from time import ticks_ms
-import jpeg
+import sys
 import gc
 
-NR = 100
-IMG_PATH = "000.jpeg"
+try:
+    from time import ticks_ms, ticks_diff
+except ImportError:
+    import time
 
-with open(IMG_PATH, "rb") as f:
-    IMG = f.read()
+    def ticks_ms():
+        return int(time.perf_counter() * 1000)
 
-def fps(n, dt_ms):
-    return n * 1000 / dt_ms if dt_ms > 0 else 0.0
+    def ticks_diff(a, b):
+        return a - b
 
-def bpp(fmt):
-    # 依你的 README 格式清單做常用 bpp 推斷
-    if fmt in ("RGB565_BE", "RGB565_LE", "CbYCrY", "YCbYCr"):
+try:
+    import jpeg
+except ImportError:
+    jpeg = None
+
+DEFAULT_IMAGE_PATH = "000.jpeg"
+
+
+def _bpp(pixel_format):
+    if pixel_format in ("RGB565_BE", "RGB565_LE", "CbYCrY", "YCbYCr", "YCbY2YCrY2"):
         return 2
-    if fmt in ("RGB888",):
-        return 3
-    if fmt in ("RGBA",):
-        return 4
-    # fallback
+    if pixel_format in ("RGB888", "RGBA"):
+        return 3 if pixel_format == "RGB888" else 4
+    if pixel_format == "GRAY":
+        return 1
     return 2
 
-def decoder_bench():
+
+def _make_decoder(pixel_format, rotation, block):
+    try:
+        return jpeg.Decoder(pixel_format=pixel_format, rotation=rotation, block=block)
+    except TypeError:
+        return jpeg.Decoder(format=pixel_format, rotation=rotation, block=block)
+
+
+def _make_encoder(height, width, pixel_format, quality, rotation):
+    try:
+        return jpeg.Encoder(height=height, width=width, pixel_format=pixel_format, quality=quality, rotation=rotation)
+    except TypeError:
+        return jpeg.Encoder(height=height, width=width, format=pixel_format, quality=quality, rotation=rotation)
+
+
+def _read_file(path):
+    with open(path, "rb") as f:
+        return f.read()
+
+
+def _pick_image_path(argv):
+    if argv:
+        for a in argv:
+            if a and not a.startswith("-"):
+                return a
+    for p in ("image.jpg", "test.jpg", "bigbuckbunny-320x240.jpg", "bigbuckbunny-160x160.jpg"):
+        try:
+            open(p, "rb").close()
+            return p
+        except OSError:
+            pass
+    return None
+
+
+def _parse_int_arg(argv, name, default):
+    prefix = "--%s=" % name
+    for a in argv:
+        if a.startswith(prefix):
+            try:
+                return int(a[len(prefix) :])
+            except ValueError:
+                return default
+    return default
+
+
+def _parse_str_arg(argv, name, default):
+    prefix = "--%s=" % name
+    for a in argv:
+        if a.startswith(prefix):
+            return a[len(prefix) :]
+    return default
+
+
+def _has_flag(argv, name):
+    return ("--%s" % name) in argv
+
+
+def _fps(frames, start_ms, end_ms):
+    dt = ticks_diff(end_ms, start_ms)
+    if dt <= 0:
+        return 0.0
+    return frames * 1000.0 / dt
+
+
+def print_image_info(jpeg_data, formats, rotation):
+    fmt0 = formats[0] if formats else "RGB565_LE"
+
     gc.collect()
-    print("Decoder Benchmark (NEW API)")
-    print("Input Image Size:", len(IMG), "bytes")
+    dec = _make_decoder(fmt0, rotation, False)
+    info = dec.get_img_info(jpeg_data)
+    w, h = info[0], info[1]
 
-    for fmt in ("RGB565_BE", "RGB565_LE", "RGB888", "CbYCrY"):
-        print("\nFormat:", fmt)
-        _bpp = bpp(fmt)
+    blocks = 0
+    block_h = 0
+    try:
+        gc.collect()
+        decb = _make_decoder(fmt0, 0, True)
+        info_b = decb.get_img_info(jpeg_data)
+        if len(info_b) >= 4:
+            blocks = info_b[2]
+            block_h = info_b[3]
+    except Exception:
+        pass
 
-        # ---- 1) normal decode (block=False) ----
-        dec = jpeg.Decoder(pixel_format=fmt, rotation=0, block=False)
-        t0 = ticks_ms()
-        for _ in range(NR):
-            _ = dec.decode(IMG)
-        dt = ticks_ms() - t0
-        print("FPS normal decode (decode, block=False):", "%.2f" % fps(NR, dt))
+    print("Image Width: %d" % w)
+    print("Image Height: %d" % h)
+    print("Rotation: %d" % rotation)
+    if blocks and block_h:
+        print("Blocks: %d" % blocks)
+        print("Block Height: %d" % block_h)
 
-        # ---- 2) block decode (decode, block=True) ----
-        dec = jpeg.Decoder(pixel_format=fmt, rotation=0, block=True)
-        info = dec.get_img_info(IMG)
+    if hasattr(gc, "mem_free"):
+        try:
+            print("GC mem_free: %d" % gc.mem_free())
+            print("GC mem_alloc: %d" % gc.mem_alloc())
+        except Exception:
+            pass
+
+    for fmt in formats:
+        bpp = _bpp(fmt)
+        frame_bytes = w * h * bpp
+        if block_h:
+            block_bytes = w * block_h * bpp
+            print("Format %s: bpp=%d framebuffer=%d bytes block=%d bytes" % (fmt, bpp, frame_bytes, block_bytes))
+        else:
+            print("Format %s: bpp=%d framebuffer=%d bytes" % (fmt, bpp, frame_bytes))
+
+
+def bench_decoder(jpeg_data, nr, formats, rotation):
+    print("Decoder Benchmark")
+    print("Input Image Size: %d bytes" % len(jpeg_data))
+
+    for fmt in formats:
+        print("\nFormat: %s" % fmt)
+        bpp = _bpp(fmt)
+
+        gc.collect()
+        dec = _make_decoder(fmt, rotation, False)
+        start = ticks_ms()
+        for _ in range(nr):
+            _ = dec.decode(jpeg_data)
+        end = ticks_ms()
+        print("FPS normal decode: %.2f" % _fps(nr, start, end))
+
+        gc.collect()
+        dec = _make_decoder(fmt, 0, True)
+        info = dec.get_img_info(jpeg_data)
         w, h, blocks = info[0], info[1], info[2]
 
-        t0 = ticks_ms()
-        for _ in range(NR):
+        start = ticks_ms()
+        for _ in range(nr):
             for _i in range(blocks):
-                _ = dec.decode(IMG)
-        dt = ticks_ms() - t0
-        print("FPS block decode (decode, block=True, blocks=%d):" % blocks, "%.2f" % fps(NR, dt))
+                _ = dec.decode(jpeg_data)
+        end = ticks_ms()
+        print("FPS block decode (%d): %.2f" % (blocks, _fps(nr, start, end)))
 
-        # ---- prepare framebuffer ----
-        fb = bytearray(w * h * _bpp)
-
-        # ---- 3) block decode + Python write (slice copy) ----
-        # 先取一塊推算 block size（只用於 slice 拼接測試）
-        dec_tmp = jpeg.Decoder(pixel_format=fmt, rotation=0, block=True, return_bytes=True)
-        _ = dec_tmp.get_img_info(IMG)
-        blk0 = dec_tmp.decode(IMG)
-        blk_size = len(blk0)
-
-        # 正式測試：每塊 decode() 回 bytes，再 slice 拷貝到 fb
-        dec3 = jpeg.Decoder(pixel_format=fmt, rotation=0, block=True, return_bytes=True)
-        _ = dec3.get_img_info(IMG)
-
-        t0 = ticks_ms()
-        for _ in range(NR):
-            for i in range(blocks):
-                blk = dec3.decode(IMG)
-                off = i * blk_size
-                fb[off:off + blk_size] = blk
-        dt = ticks_ms() - t0
-        print("FPS block decode + write (python slice):", "%.2f" % fps(NR, dt))
-
-        # ---- 4) NEW: decode_into step (blocks=1) ----
-        # 每輪做 blocks 次，每次做 1 block，done 只有最後一次會 True
-        dec4 = jpeg.Decoder(pixel_format=fmt, rotation=0, block=True)
-        _ = dec4.get_img_info(IMG)
-
-        t0 = ticks_ms()
-        for _ in range(NR):
-            for _i in range(blocks):
-                done = dec4.decode_into(IMG, fb, blocks=1)
-        dt = ticks_ms() - t0
-        print("FPS decode_into step (blocks=1):", "%.2f" % fps(NR, dt))
-
-        # ---- 5) NEW: decode_into full (default blocks=0) ----
-        # 每輪只呼叫一次，應該直接完成一輪 (done=True)
-        dec5 = jpeg.Decoder(pixel_format=fmt, rotation=0, block=True)
-        _ = dec5.get_img_info(IMG)
-
-        t0 = ticks_ms()
-        for _ in range(NR):
-            done = dec5.decode_into(IMG, fb)  # default blocks=0 (full)
-            # 理論上 done 應為 True
-        dt = ticks_ms() - t0
-        print("FPS decode_into full (default blocks=0):", "%.2f" % fps(NR, dt))
-
-
-def encoder_bench():
-    print("\nEncoder Benchmark")
-    # 先解成 RGB888 當作 encoder input
-    dec = jpeg.Decoder(pixel_format="RGB888", rotation=0, block=False)
-    info = dec.get_img_info(IMG)
-    w, h = info[0], info[1]
-    img_dec = bytes(dec.decode(IMG))
-    del dec
-    gc.collect()
-
-    for q in (100, 90, 80, 70, 60):
-        enc = jpeg.Encoder(pixel_format="RGB888", quality=q, height=h, width=w)
-        t0 = ticks_ms()
-        for _ in range(NR):
-            _ = enc.encode(img_dec)
-        dt = ticks_ms() - t0
-        print("FPS encode quality %d:" % q, "%.2f" % fps(NR, dt))
         gc.collect()
+        dec = _make_decoder(fmt, 0, True)
+        info = dec.get_img_info(jpeg_data)
+        w, h, blocks = info[0], info[1], info[2]
+        fb = bytearray(w * h * bpp)
+        start = ticks_ms()
+        for _ in range(nr):
+            for i in range(blocks):
+                block = dec.decode(jpeg_data)
+                off = i * len(block)
+                fb[off : off + len(block)] = block
+        end = ticks_ms()
+        print("FPS block decode + write (slice) (%d): %.2f" % (blocks, _fps(nr, start, end)))
+
+        gc.collect()
+        dec = _make_decoder(fmt, 0, True)
+        info = dec.get_img_info(jpeg_data)
+        w, h, blocks = info[0], info[1], info[2]
+        fb = bytearray(w * h * bpp)
+        start = ticks_ms()
+        for _ in range(nr):
+            for _i in range(blocks):
+                _ = dec.decode_into(jpeg_data, fb, blocks=1)
+        end = ticks_ms()
+        print("FPS decode_into step (blocks=1): %.2f" % _fps(nr, start, end))
+
+        gc.collect()
+        dec = _make_decoder(fmt, 0, True)
+        info = dec.get_img_info(jpeg_data)
+        w, h = info[0], info[1]
+        fb = bytearray(w * h * bpp)
+        start = ticks_ms()
+        for _ in range(nr):
+            _ = dec.decode_into(jpeg_data, fb)
+        end = ticks_ms()
+        print("FPS decode_into full (blocks=0): %.2f" % _fps(nr, start, end))
 
 
-decoder_bench()
-encoder_bench()
+def bench_encoder(jpeg_data, nr, quality_list, rotation):
+    print("\nEncoder Benchmark")
+
+    gc.collect()
+    dec = _make_decoder("RGB888", rotation, False)
+    info = dec.get_img_info(jpeg_data)
+    w, h = info[0], info[1]
+    img_raw = bytes(dec.decode(jpeg_data))
+
+    for q in quality_list:
+        gc.collect()
+        enc = _make_encoder(h, w, "RGB888", q, rotation)
+        start = ticks_ms()
+        for _ in range(nr):
+            _ = enc.encode(img_raw)
+        end = ticks_ms()
+        print("FPS encode quality %d: %.2f" % (q, _fps(nr, start, end)))
+
+
+def main():
+    argv = sys.argv[1:]
+
+    if _has_flag(argv, "help") or _has_flag(argv, "h"):
+        print(
+            "Usage: benchmark.py [image.jpg] [--image=path] [--nr=N] [--rotation=0|90|180|270] "
+            "[--formats=CSV] [--qualities=CSV] [--no-encoder]"
+        )
+        return 0
+
+    if jpeg is None:
+        print("jpeg module not found (this benchmark is for MicroPython build with mp_jpeg).")
+        return 2
+
+    img_path = _parse_str_arg(argv, "image", "")
+    if not img_path:
+        img_path = _pick_image_path(argv)
+    if not img_path:
+        img_path = DEFAULT_IMAGE_PATH
+    try:
+        open(img_path, "rb").close()
+    except OSError:
+        print("No JPEG file found. Edit DEFAULT_IMAGE_PATH in benchmark.py or pass: benchmark.py image.jpg")
+        return 2
+
+    nr = _parse_int_arg(argv, "nr", 100)
+    rotation = _parse_int_arg(argv, "rotation", 0)
+
+    fmt_csv = _parse_str_arg(argv, "formats", "RGB565_BE,RGB565_LE,RGB888,CbYCrY")
+    formats = [s.strip() for s in fmt_csv.split(",") if s.strip()]
+    if not formats:
+        formats = ["RGB565_LE"]
+
+    q_csv = _parse_str_arg(argv, "qualities", "100,90,80,70,60")
+    qualities = []
+    for s in q_csv.split(","):
+        s = s.strip()
+        if not s:
+            continue
+        try:
+            qualities.append(int(s))
+        except ValueError:
+            pass
+    if not qualities:
+        qualities = [90]
+
+    jpeg_data = _read_file(img_path)
+
+    print("JPEG Driver Version: %s" % jpeg.version())
+    print("Image: %s" % img_path)
+    print("NR: %d" % nr)
+    print_image_info(jpeg_data, formats, rotation)
+
+    bench_decoder(jpeg_data, nr, formats, rotation)
+
+    if not _has_flag(argv, "no-encoder"):
+        bench_encoder(jpeg_data, nr, qualities, rotation)
+
+    return 0
+
+
+raise SystemExit(main())

--- a/src/jpeg_esp.c
+++ b/src/jpeg_esp.c
@@ -112,24 +112,27 @@ static mp_obj_t jpeg_decoder_make_new(const mp_obj_type_t *type, size_t n_args, 
     self->block_pos = 0;
     self->block_counts = 0;
     self->handle = NULL;
-
     self->config = (jpeg_dec_config_t)DEFAULT_JPEG_DEC_CONFIG();
     self->config.block_enable = parsed_args[ARG_block].u_bool;
-    if (parsed_args[ARG_rotation].u_obj != mp_const_none) {
-        self->config.rotate = jpeg_get_rotation_code(parsed_args[ARG_rotation].u_int);
-    }
+    
+    // Fix: Use u_int directly; no need to check u_obj.
+    self->config.rotate = jpeg_get_rotation_code(parsed_args[ARG_rotation].u_int);
+    
+    // Fix: Correctly checks pixel_format
     if (parsed_args[ARG_pixel_format].u_obj != mp_const_none) {
         self->config.output_type = jpeg_get_format_code(mp_obj_str_get_str(parsed_args[ARG_pixel_format].u_obj));
     }
+    
     if (parsed_args[ARG_scale_width].u_int > 0 && parsed_args[ARG_scale_height].u_int > 0) {
         self->config.scale.width = parsed_args[ARG_scale_width].u_int;
         self->config.scale.height = parsed_args[ARG_scale_height].u_int;
     }
+    
     if (parsed_args[ARG_clipper_width].u_int > 0 && parsed_args[ARG_clipper_height].u_int > 0) {
         self->config.clipper.width = parsed_args[ARG_clipper_width].u_int;
         self->config.clipper.height = parsed_args[ARG_clipper_height].u_int;
     }
-
+    
     if (self->config.block_enable) {
         if (self->config.rotate != JPEG_ROTATE_0D) {
             mp_raise_msg(&mp_type_ValueError, MP_ERROR_TEXT("Block decoding is only supported for rotation 0"));
@@ -141,13 +144,10 @@ static mp_obj_t jpeg_decoder_make_new(const mp_obj_type_t *type, size_t n_args, 
             mp_raise_msg(&mp_type_ValueError, MP_ERROR_TEXT("Block decoding does not support clipping"));
         }
     }
-
-    if (parsed_args[ARG_return_bytes].u_bool) {
-        self->return_bytes = true;
-    } else {
-        self->return_bytes = false;
-    }
-
+    
+    self->return_bytes = parsed_args[ARG_return_bytes].u_bool;
+    
+    // Open the JPEG decoder
     jpeg_error_t ret = jpeg_dec_open(&self->config, &self->handle);
     if (ret != JPEG_ERR_OK) {
         jpeg_err_to_mp_exception(ret, "Failed to initialize JPEG decoder object");

--- a/src/jpeg_esp.c
+++ b/src/jpeg_esp.c
@@ -112,27 +112,24 @@ static mp_obj_t jpeg_decoder_make_new(const mp_obj_type_t *type, size_t n_args, 
     self->block_pos = 0;
     self->block_counts = 0;
     self->handle = NULL;
+
     self->config = (jpeg_dec_config_t)DEFAULT_JPEG_DEC_CONFIG();
     self->config.block_enable = parsed_args[ARG_block].u_bool;
-    
-    // Fix: Use u_int directly; no need to check u_obj.
-    self->config.rotate = jpeg_get_rotation_code(parsed_args[ARG_rotation].u_int);
-    
-    // Fix: Correctly checks pixel_format
+    if (parsed_args[ARG_rotation].u_obj != mp_const_none) {
+        self->config.rotate = jpeg_get_rotation_code(parsed_args[ARG_rotation].u_int);
+    }
     if (parsed_args[ARG_pixel_format].u_obj != mp_const_none) {
         self->config.output_type = jpeg_get_format_code(mp_obj_str_get_str(parsed_args[ARG_pixel_format].u_obj));
     }
-    
     if (parsed_args[ARG_scale_width].u_int > 0 && parsed_args[ARG_scale_height].u_int > 0) {
         self->config.scale.width = parsed_args[ARG_scale_width].u_int;
         self->config.scale.height = parsed_args[ARG_scale_height].u_int;
     }
-    
     if (parsed_args[ARG_clipper_width].u_int > 0 && parsed_args[ARG_clipper_height].u_int > 0) {
         self->config.clipper.width = parsed_args[ARG_clipper_width].u_int;
         self->config.clipper.height = parsed_args[ARG_clipper_height].u_int;
     }
-    
+
     if (self->config.block_enable) {
         if (self->config.rotate != JPEG_ROTATE_0D) {
             mp_raise_msg(&mp_type_ValueError, MP_ERROR_TEXT("Block decoding is only supported for rotation 0"));
@@ -144,10 +141,13 @@ static mp_obj_t jpeg_decoder_make_new(const mp_obj_type_t *type, size_t n_args, 
             mp_raise_msg(&mp_type_ValueError, MP_ERROR_TEXT("Block decoding does not support clipping"));
         }
     }
-    
-    self->return_bytes = parsed_args[ARG_return_bytes].u_bool;
-    
-    // Open the JPEG decoder
+
+    if (parsed_args[ARG_return_bytes].u_bool) {
+        self->return_bytes = true;
+    } else {
+        self->return_bytes = false;
+    }
+
     jpeg_error_t ret = jpeg_dec_open(&self->config, &self->handle);
     if (ret != JPEG_ERR_OK) {
         jpeg_err_to_mp_exception(ret, "Failed to initialize JPEG decoder object");
@@ -251,55 +251,120 @@ static MP_DEFINE_CONST_FUN_OBJ_2(jpeg_decoder_get_img_info_obj, jpeg_decoder_get
 // }
 // static MP_DEFINE_CONST_FUN_OBJ_2(jpeg_decoder_decode_obj, jpeg_decoder_decode);
 
-// Add the decode_into function to the jpeg module
-static mp_obj_t jpeg_decoder_decode_into(size_t n_args, const mp_obj_t *args) {
-    mp_obj_t self_in = args[0];
-    mp_obj_t jpeg_data = args[1];
-    mp_obj_t out_buffer = args[2];  // 必需參數
-    
+// decode_into(self, jpeg_data, out_buffer, *, blocks=0) -> bool
+//
+// blocks 語義：
+// - blocks=0 (default): FULL，從目前進度一路做到完成一輪
+// - blocks>0: 步進 blocks 個 block（若不足則做到完成）
+// - blocks<0: ValueError
+//
+// 回傳：
+// - True  : 本次呼叫結束後完成一輪（framebuffer 可用）
+// - False : 尚未完成（只在 block=True 且 blocks>0 且 remaining>blocks 時會發生）
+//
+// 特性：auto-rewind
+// - 若上一輪已完成且你不換圖，下一次呼叫會在 prepare() 內自動 reset，開始新一輪
+static mp_obj_t jpeg_decoder_decode_into(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+    enum { ARG_blocks };
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_blocks, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0} }, // default FULL
+    };
+
+    mp_arg_val_t parsed[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all(n_args - 3, pos_args + 3, kw_args,
+                     MP_ARRAY_SIZE(allowed_args), allowed_args, parsed);
+
+    mp_obj_t self_in = pos_args[0];
+    mp_obj_t jpeg_data = pos_args[1];
+    mp_obj_t out_buffer = pos_args[2];
+
     jpeg_decoder_obj_t *self = jpeg_decoder_prepare(self_in, jpeg_data);
-    
-    // Get external buffer information
+
     mp_buffer_info_t bufinfo;
     mp_get_buffer_raise(out_buffer, &bufinfo, MP_BUFFER_WRITE);
-    
-    // Verify buffer size and alignment
-    if (bufinfo.len < self->io.out_size) {
-        mp_raise_msg_varg(&mp_type_ValueError, 
-            MP_ERROR_TEXT("Buffer too small: need %d bytes, got %d"), 
-            self->io.out_size, bufinfo.len);
-    }
-    
-    // Check if it is an aligned buffer (optional, but recommended for DMA)
+
+    // alignment warning (optional)
     if (((uintptr_t)bufinfo.buf & 0x0F) != 0) {
-        mp_printf(&mp_plat_print, 
+        mp_printf(&mp_plat_print,
             "Warning: Buffer not 16-byte aligned, may impact DMA performance\n");
     }
-    
-    // Decode to external buffer
-    if (self->block_pos < self->block_counts) {
-        // Temporarily replace the output buffer pointer
-        uint8_t *orig_buf = self->io.outbuf;
+
+    mp_int_t blocks = parsed[ARG_blocks].u_int;
+    if (blocks < 0) {
+        mp_raise_msg(&mp_type_ValueError, MP_ERROR_TEXT("blocks must be >= 0"));
+    }
+
+    // --- Non-block mode: always one-shot FULL ---
+    if (!self->config.block_enable) {
+        if (bufinfo.len < (size_t)self->io.out_size) {
+            mp_raise_msg_varg(&mp_type_ValueError,
+                MP_ERROR_TEXT("Buffer too small: need %d bytes, got %d"),
+                self->io.out_size, (int)bufinfo.len);
+        }
+
+        uint8_t *orig = self->io.outbuf;
         self->io.outbuf = (uint8_t *)bufinfo.buf;
-        
+
         jpeg_error_t ret = jpeg_dec_process(self->handle, &self->io);
-        
-        // Restore internal buffer pointer
-        self->io.outbuf = orig_buf;
-        
+
+        self->io.outbuf = orig;
+
         if (ret != JPEG_ERR_OK) {
             jpeg_err_to_mp_exception(ret, "JPEG decoding failed");
         }
-        
-        self->block_pos++;
-        
-        // Returns the number of bytes actually written (following the readinto convention)
-        return mp_obj_new_int(self->io.out_size);
+
+        // one-shot always completes a "round"
+        self->block_pos = self->block_counts;
+        return mp_const_true;
     }
-    
-    return mp_obj_new_int(0);  // No more data
+
+    // --- Block mode ---
+    // blocks==0 => FULL (run to end), blocks>0 => step
+    mp_int_t remaining = self->block_counts - self->block_pos;
+    if (remaining <= 0) {
+        // already done for this round
+        return mp_const_true;
+    }
+
+    mp_int_t todo = (blocks == 0) ? remaining : blocks;
+    if (todo > remaining) {
+        todo = remaining; // saturate
+    }
+
+    // Need full framebuffer: block_counts * blk_size
+    size_t blk_size = (size_t)self->io.out_size;
+    size_t need = (size_t)self->block_counts * blk_size;
+    if (bufinfo.len < need) {
+        mp_raise_msg_varg(&mp_type_ValueError,
+            MP_ERROR_TEXT("Framebuffer too small: need %d bytes, got %d"),
+            (int)need, (int)bufinfo.len);
+    }
+
+    uint8_t *base = (uint8_t *)bufinfo.buf;
+    uint8_t *orig = self->io.outbuf;
+
+    for (mp_int_t i = 0; i < todo; i++) {
+        mp_int_t idx = self->block_pos; // current block index
+        self->io.outbuf = base + ((size_t)idx * blk_size);
+
+        jpeg_error_t ret = jpeg_dec_process(self->handle, &self->io);
+        if (ret != JPEG_ERR_OK) {
+            self->io.outbuf = orig;
+            jpeg_err_to_mp_exception(ret, "JPEG decoding failed");
+        }
+
+        self->block_pos++;
+    }
+
+    self->io.outbuf = orig;
+
+    // done for this round?
+    if (self->block_pos >= self->block_counts) {
+        return mp_const_true;
+    }
+    return mp_const_false;
 }
-static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(jpeg_decoder_decode_into_obj, 3, 3, jpeg_decoder_decode_into);
+static MP_DEFINE_CONST_FUN_OBJ_KW(jpeg_decoder_decode_into_obj, 3, jpeg_decoder_decode_into);
 
 
 static mp_obj_t jpeg_decoder_decode_block(mp_obj_t self_in, mp_obj_t jpeg_data) {

--- a/src/jpeg_esp.c
+++ b/src/jpeg_esp.c
@@ -251,6 +251,57 @@ static MP_DEFINE_CONST_FUN_OBJ_2(jpeg_decoder_get_img_info_obj, jpeg_decoder_get
 // }
 // static MP_DEFINE_CONST_FUN_OBJ_2(jpeg_decoder_decode_obj, jpeg_decoder_decode);
 
+// Add the decode_into function to the jpeg module
+static mp_obj_t jpeg_decoder_decode_into(size_t n_args, const mp_obj_t *args) {
+    mp_obj_t self_in = args[0];
+    mp_obj_t jpeg_data = args[1];
+    mp_obj_t out_buffer = args[2];  // 必需參數
+    
+    jpeg_decoder_obj_t *self = jpeg_decoder_prepare(self_in, jpeg_data);
+    
+    // Get external buffer information
+    mp_buffer_info_t bufinfo;
+    mp_get_buffer_raise(out_buffer, &bufinfo, MP_BUFFER_WRITE);
+    
+    // Verify buffer size and alignment
+    if (bufinfo.len < self->io.out_size) {
+        mp_raise_msg_varg(&mp_type_ValueError, 
+            MP_ERROR_TEXT("Buffer too small: need %d bytes, got %d"), 
+            self->io.out_size, bufinfo.len);
+    }
+    
+    // Check if it is an aligned buffer (optional, but recommended for DMA)
+    if (((uintptr_t)bufinfo.buf & 0x0F) != 0) {
+        mp_printf(&mp_plat_print, 
+            "Warning: Buffer not 16-byte aligned, may impact DMA performance\n");
+    }
+    
+    // Decode to external buffer
+    if (self->block_pos < self->block_counts) {
+        // Temporarily replace the output buffer pointer
+        uint8_t *orig_buf = self->io.outbuf;
+        self->io.outbuf = (uint8_t *)bufinfo.buf;
+        
+        jpeg_error_t ret = jpeg_dec_process(self->handle, &self->io);
+        
+        // Restore internal buffer pointer
+        self->io.outbuf = orig_buf;
+        
+        if (ret != JPEG_ERR_OK) {
+            jpeg_err_to_mp_exception(ret, "JPEG decoding failed");
+        }
+        
+        self->block_pos++;
+        
+        // Returns the number of bytes actually written (following the readinto convention)
+        return mp_obj_new_int(self->io.out_size);
+    }
+    
+    return mp_obj_new_int(0);  // No more data
+}
+static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(jpeg_decoder_decode_into_obj, 3, 3, jpeg_decoder_decode_into);
+
+
 static mp_obj_t jpeg_decoder_decode_block(mp_obj_t self_in, mp_obj_t jpeg_data) {
     jpeg_decoder_obj_t *self = jpeg_decoder_prepare(self_in, jpeg_data);
     // decode the next block
@@ -290,6 +341,7 @@ static const mp_rom_map_elem_t jpeg_decoder_locals_dict_table[] = {
     // {MP_ROM_QSTR(MP_QSTR_decode), MP_ROM_PTR(&jpeg_decoder_decode_obj)},
     // {MP_ROM_QSTR(MP_QSTR_decode_block), MP_ROM_PTR(&jpeg_decoder_decode_block_obj)},
     {MP_ROM_QSTR(MP_QSTR_decode), MP_ROM_PTR(&jpeg_decoder_decode_block_obj)},
+    {MP_ROM_QSTR(MP_QSTR_decode_into), MP_ROM_PTR(&jpeg_decoder_decode_into_obj)},
     {MP_ROM_QSTR(MP_QSTR_get_img_info), MP_ROM_PTR(&jpeg_decoder_get_img_info_obj)},
     {MP_ROM_QSTR(MP_QSTR___del__), MP_ROM_PTR(&jpeg_decoder_del_obj)},
     {MP_ROM_QSTR(MP_QSTR___enter__), MP_ROM_PTR(&mp_identity_obj)},

--- a/src/jpeg_esp.c
+++ b/src/jpeg_esp.c
@@ -253,17 +253,17 @@ static MP_DEFINE_CONST_FUN_OBJ_2(jpeg_decoder_get_img_info_obj, jpeg_decoder_get
 
 // decode_into(self, jpeg_data, out_buffer, *, blocks=0) -> bool
 //
-// blocks 語義：
-// - blocks=0 (default): FULL，從目前進度一路做到完成一輪
-// - blocks>0: 步進 blocks 個 block（若不足則做到完成）
+// blocks semantics:
+// - blocks=0 (default): FULL; continue from current progress until one full frame is completed
+// - blocks>0: STEP; decode up to `blocks` blocks from current progress (or finish the frame earlier)
 // - blocks<0: ValueError
 //
-// 回傳：
-// - True  : 本次呼叫結束後完成一輪（framebuffer 可用）
-// - False : 尚未完成（只在 block=True 且 blocks>0 且 remaining>blocks 時會發生）
+// Return value:
+// - True  : this call completes one full decode round (framebuffer is ready)
+// - False : not finished yet (only possible when block=True and blocks>0 and remaining>blocks)
 //
-// 特性：auto-rewind
-// - 若上一輪已完成且你不換圖，下一次呼叫會在 prepare() 內自動 reset，開始新一輪
+// Behavior: auto-rewind
+// - After a round is completed, calling decode_into() again with the same jpeg_data will auto-reset in prepare() and start a new round
 static mp_obj_t jpeg_decoder_decode_into(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_blocks };
     static const mp_arg_t allowed_args[] = {


### PR DESCRIPTION
## Summary
This PR improves the documentation for the new Decoder.decode_into() API and refreshes benchmark results using an ESP32S3 run. The goal is to clarify how decode_into() should be used for framebuffer-oriented rendering, including both FULL and STEP (cooperative) modes.

## Changes
- README
  - Added a practical guide for decode_into() :
    - Framebuffer sizing by pixel format (bytes-per-pixel)
    - FULL decode vs STEP decode usage examples
    - Correct STEP loop pattern ( blocks>0 until done=True )
    - Guidance on when to use decode_into() vs decode(block=True)
    - Notes on block-mode limitations and auto-rewind behavior
  - Updated Benchmark section with the latest ESP32S3 results (240×240 image and new result tables)
- Benchmark script
  - Updated the benchmark script to print richer image metadata (width/height, blocks, block height, GC stats if available, and per-format framebuffer size)
  - Keeps a static default image path in the file ( DEFAULT_IMAGE_PATH ) for quick re-runs
## Benchmark Environment
- Board: ESP32S3
- JPEG Driver Version: 1.0.0
- Image: 000.jpeg
- Resolution: 240×240
- JPEG size: 32,627 bytes
- Blocks: 30 (block height: 8 )
- NR: 100
## Results
### Decoder FPS
Format FPS normal decode ( decode , block=False) FPS block decode ( decode , block=True) FPS block decode + write (python slice) FPS decode_into step (blocks=1) FPS decode_into full (blocks=0) RGB565_BE 18.47 24.65 4.82 21.38 21.52 RGB565_LE 18.46 24.65 4.82 21.40 21.52 RGB888 16.49 23.75 3.43 20.19 20.34 CbYCrY 18.92 26.03 4.85 21.99 22.13

### Encoder FPS (RGB888)
Quality FPS 100 10.95 90 16.88 80 19.18 70 20.23 60 22.46

## Performance Comparison (non-exaggerated)
decode_into() mainly improves the decode + write-to-framebuffer workflow by writing directly into a user-provided buffer and avoiding Python-level slice assembly. The module still supports direct decode() for full-frame output.

### A) Full-frame workflow: decode_into(full) vs decode(normal)
This compares “get a full frame result” in one call path.

- RGB565_BE : 18.47 → 21.52 FPS ( +16.5% )
- RGB565_LE : 18.46 → 21.52 FPS ( +16.6% )
- RGB888 : 16.49 → 20.34 FPS ( +23.4% )
- CbYCrY : 18.92 → 22.13 FPS ( +16.9% )
### B) Framebuffer assembly path: decode_into(full) vs block decode + Python slice write
This reflects the common UI case where blocks must be placed into a full framebuffer.

- RGB565_BE : 4.82 → 21.52 FPS ( 4.46× )
- RGB565_LE : 4.82 → 21.52 FPS ( 4.46× )
- RGB888 : 3.43 → 20.34 FPS ( 5.93× )
- CbYCrY : 4.85 → 22.13 FPS ( 4.56× )
### C) Cooperative scheduling: decode_into(step) vs decode_into(full)
STEP mode shows minimal overhead in this test (typically within ~0.5–1 FPS), making it practical for responsive UI loops.

## Notes
- STEP mode ( blocks>0 ) is intended for cooperative decoding; keep calling until done=True .
- In block=True mode: rotation must be 0, and scaling/clipping are not supported.
- The decoder auto-rewinds after completing a full decode round when decode_into() is called again with the same jpeg_data , which is convenient for animation loops.
## Testing
- Ran the benchmark on-device (ESP32S3) and captured the results above.
## Breaking Changes
- None.